### PR TITLE
adding close() on temp file for fixing bug #15 and #51

### DIFF
--- a/StanfordDependencies/SubprocessBackend.py
+++ b/StanfordDependencies/SubprocessBackend.py
@@ -55,6 +55,7 @@ class SubprocessBackend(StanfordDependencies):
                 tree_with_line_break = ptb_tree + "\n"
                 input_file.write(tree_with_line_break.encode("utf-8"))
             input_file.flush()
+            input_file.close()
 
             command = [self.java_command,
                        '-ea',


### PR DESCRIPTION
Closing the temp file before trying to remove it. solving error code 32 "WindowsError: [Error 32] The process cannot access the file: tempfile" on bugs #15 and #51