### PR TITLE
Drop Python 2.6 support, ignore new flake8 checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ before_script:
 script:
   - pip install .
   - nosetests -v --with-coverage --cover-package=StanfordDependencies
-  - flake8 --ignore=E301,E302,E261 StanfordDependencies
+  - flake8 --ignore=E301,E302,E305,E306,E261 StanfordDependencies
 after_success:
   - coveralls

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ class Test(Command):
     def finalize_options(self):
         pass
     def run(self):
-        self.run_command('flake8', '--ignore=E301,E302,E261',
+        self.run_command('flake8', '--ignore=E301,E302,E305,E306,E261',
                          'StanfordDependencies')
         self.run_command('nosetests-2.7', '-dvx')
         self.run_command('nosetests-3.4', '-dvx')

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, pypy, jython
+envlist = py27, py32, py33, py34, py35, pypy, jython
 
 [testenv]
 commands = nosetests -v --with-coverage --cover-package=StanfordDependencies


### PR DESCRIPTION
flake8 and Travis CI can't test Python 2.6 anymore which seems as good a reason as any to consider it deprecated.